### PR TITLE
Add experimental Rust OSPF module

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Instructions on building and installing from source for supported platforms may
 be found in the
 [developer docs](http://docs.frrouting.org/projects/dev-guide/en/latest/building.html).
 
+An experimental Rust workspace lives in `rust/`. If the `cargo` tool is
+available, the Rust components can be compiled with `cargo build`.
+
 Once installed, please refer to the [user guide](http://docs.frrouting.org/)
 for instructions on use.
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["ospf"]
+

--- a/rust/ospf/Cargo.toml
+++ b/rust/ospf/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ospf"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+

--- a/rust/ospf/src/lib.rs
+++ b/rust/ospf/src/lib.rs
@@ -1,0 +1,76 @@
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum OspfHelperExitReason {
+    None = 0,
+    InProgress,
+    TopologyChange,
+    GraceTimeout,
+    Completed,
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum OspfGrRestartReason {
+    UnknownRestart = 0,
+    SoftwareRestart = 1,
+    SoftwareUpgrade = 2,
+    SwitchRedundantCard = 3,
+    InvalidReasonCode = 4,
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum OspfGrHelperRejectedReason {
+    None = 0,
+    SupportDisabled,
+    NotAValidNeighbour,
+    PlannedOnlyRestart,
+    TopologyChangeRtxmtList,
+    LsaAgeMore,
+    Restarting,
+}
+
+pub fn ospf_exit_reason2str(reason: OspfHelperExitReason) -> &'static str {
+    match reason {
+        OspfHelperExitReason::None => "Unknown reason",
+        OspfHelperExitReason::InProgress => "Helper in progress",
+        OspfHelperExitReason::TopologyChange => "Topology Change",
+        OspfHelperExitReason::GraceTimeout => "Grace timer expiry",
+        OspfHelperExitReason::Completed => "Successful graceful restart",
+    }
+}
+
+pub fn ospf_restart_reason2str(reason: OspfGrRestartReason) -> &'static str {
+    match reason {
+        OspfGrRestartReason::UnknownRestart => "Unknown restart",
+        OspfGrRestartReason::SoftwareRestart => "Software restart",
+        OspfGrRestartReason::SoftwareUpgrade => "Software reload/upgrade",
+        OspfGrRestartReason::SwitchRedundantCard => "Switch to redundant control processor",
+        OspfGrRestartReason::InvalidReasonCode => "Invalid reason",
+    }
+}
+
+pub fn ospf_rejected_reason2str(reason: OspfGrHelperRejectedReason) -> &'static str {
+    match reason {
+        OspfGrHelperRejectedReason::None => "Unknown reason",
+        OspfGrHelperRejectedReason::SupportDisabled => "Helper support disabled",
+        OspfGrHelperRejectedReason::NotAValidNeighbour => "Neighbour is not in FULL state",
+        OspfGrHelperRejectedReason::PlannedOnlyRestart => "Supports only planned restart but received unplanned",
+        OspfGrHelperRejectedReason::TopologyChangeRtxmtList => "Topo change due to change in lsa rxmt list",
+        OspfGrHelperRejectedReason::LsaAgeMore => "LSA age is more than Grace interval",
+        OspfGrHelperRejectedReason::Restarting => "Router is in the process of graceful restart",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reason_strings() {
+        assert_eq!(ospf_exit_reason2str(OspfHelperExitReason::None), "Unknown reason");
+        assert_eq!(ospf_restart_reason2str(OspfGrRestartReason::SoftwareRestart), "Software restart");
+        assert_eq!(ospf_rejected_reason2str(OspfGrHelperRejectedReason::Restarting), "Router is in the process of graceful restart");
+    }
+}
+


### PR DESCRIPTION
## Summary
- start Rust workspace with an `ospf` crate
- implement OSPF Graceful Restart enums in Rust
- provide helpers returning string equivalents
- document how to build the Rust workspace

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6862aecef2488332a7e5a6388ec35047